### PR TITLE
fix(deps): address security vulnerabilities (bigint-buffer)

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
     "tmp": "0.2.5",
     "undici": "6.23.0",
     "@openzeppelin/contracts": "5.4.0",
-    "@openzeppelin/contracts-upgradeable": "5.4.0"
+    "@openzeppelin/contracts-upgradeable": "5.4.0",
+    "bigint-buffer": "npm:@trufflesuite/bigint-buffer@^1.1.9"
   },
   "pnpm": {
     "overrides": {
@@ -159,7 +160,8 @@
       "@openzeppelin/contracts@<5": "4.9.6",
       "@openzeppelin/contracts-upgradeable@<5": "4.9.6",
       "@openzeppelin/contracts@>=5": "5.4.0",
-      "@openzeppelin/contracts-upgradeable@>=5": "5.4.0"
+      "@openzeppelin/contracts-upgradeable@>=5": "5.4.0",
+      "bigint-buffer": "npm:@trufflesuite/bigint-buffer@^1.1.9"
     }
   },
   "dependencies": {

--- a/solana/package.json
+++ b/solana/package.json
@@ -76,7 +76,8 @@
     "undici": "6.23.0",
     "@openzeppelin/contracts": "5.4.0",
     "@openzeppelin/contracts-upgradeable": "5.4.0",
-    "serialize-javascript": "7.0.3"
+    "serialize-javascript": "7.0.3",
+    "bigint-buffer": "npm:@trufflesuite/bigint-buffer@^1.1.9"
   },
   "devDependencies": {
     "@coral-xyz/anchor": "^0.29.0",
@@ -212,7 +213,8 @@
       "@openzeppelin/contracts-upgradeable@<5": "4.9.6",
       "@openzeppelin/contracts@>=5": "5.4.0",
       "@openzeppelin/contracts-upgradeable@>=5": "5.4.0",
-      "serialize-javascript": "7.0.3"
+      "serialize-javascript": "7.0.3",
+      "bigint-buffer": "npm:@trufflesuite/bigint-buffer@^1.1.9"
     }
   },
   "overrides": {

--- a/solana/pnpm-lock.yaml
+++ b/solana/pnpm-lock.yaml
@@ -43,6 +43,7 @@ overrides:
   '@openzeppelin/contracts': 5.4.0
   '@openzeppelin/contracts-upgradeable': 5.4.0
   serialize-javascript: 7.0.3
+  bigint-buffer: npm:@trufflesuite/bigint-buffer@^1.1.9
   form-data@<3: 2.5.5
   form-data@>=4: 4.0.5
   ws@>=7: 7.5.10
@@ -2346,19 +2347,12 @@ packages:
   bech32@2.0.0:
     resolution: {integrity: sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==}
 
-  bigint-buffer@1.1.5:
-    resolution: {integrity: sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==}
-    engines: {node: '>= 10.0.0'}
-
   bignumber.js@9.1.2:
     resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
-
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   bip32@5.0.0-rc.0:
     resolution: {integrity: sha512-5hVFGrdCnF8GB1Lj2eEo4PRE7+jp+3xBLnfNjydivOkMvKmUKeJ9GG8uOy8prmWl3Oh154uzgfudR1FRkNBudA==}
@@ -3364,9 +3358,6 @@ packages:
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
-
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -8309,7 +8300,7 @@ snapshots:
     dependencies:
       '@solana/buffer-layout': 4.0.1
       '@solana/web3.js': 1.95.8(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      bigint-buffer: 1.1.5
+      bigint-buffer: '@trufflesuite/bigint-buffer@1.1.9'
       bignumber.js: 9.1.2
     transitivePeerDependencies:
       - bufferutil
@@ -8426,7 +8417,7 @@ snapshots:
       '@noble/hashes': 1.7.1
       '@solana/buffer-layout': 4.0.1
       agentkeepalive: 4.6.0
-      bigint-buffer: 1.1.5
+      bigint-buffer: '@trufflesuite/bigint-buffer@1.1.9'
       bn.js: 5.2.3
       borsh: 0.7.0
       bs58: 4.0.1
@@ -8553,7 +8544,6 @@ snapshots:
   '@trufflesuite/bigint-buffer@1.1.9':
     dependencies:
       node-gyp-build: 4.3.0
-    optional: true
 
   '@tsconfig/node10@1.0.11': {}
 
@@ -9161,17 +9151,9 @@ snapshots:
 
   bech32@2.0.0: {}
 
-  bigint-buffer@1.1.5:
-    dependencies:
-      bindings: 1.5.0
-
   bignumber.js@9.1.2: {}
 
   binary-extensions@2.3.0: {}
-
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
 
   bip32@5.0.0-rc.0(typescript@5.7.3):
     dependencies:
@@ -10458,8 +10440,6 @@ snapshots:
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
-
-  file-uri-to-path@1.0.0: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -12040,8 +12020,7 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
-  node-gyp-build@4.3.0:
-    optional: true
+  node-gyp-build@4.3.0: {}
 
   node-gyp-build@4.8.4: {}
 


### PR DESCRIPTION
## Summary
Address security vulnerabilities for Vanta compliance (Due Mar 29).

### Fixed
- **bigint-buffer** CVE-2025-3194: Redirected to `@trufflesuite/bigint-buffer@^1.1.9` via resolutions/overrides (no upstream fix available for original package)

### Already mitigated
- **@openzeppelin/contracts** CVE-2021-46320: Direct deps at 5.4.0+, overrides pin <5 to 4.9.6 (>=4.4.1)
- **@openzeppelin/contracts-upgradeable** CVE-2023-30542: Direct deps at 5.4.0+, overrides pin <5 to 4.9.6 (>=4.8.3)

### Cannot fully remediate
- The 3.4.2 and 4.7.3 OpenZeppelin versions come from `@chainlink/contracts-ccip` npm aliases and cannot be overridden without breaking Chainlink compatibility. Deployed contracts use v5.4.0+.

## Test plan
- [ ] Verify `yarn install` and `pnpm install` succeed
- [ ] Verify `forge build` succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)